### PR TITLE
Added the ability to refresh the current tab

### DIFF
--- a/DependenciesGui/MainWindow.xaml
+++ b/DependenciesGui/MainWindow.xaml
@@ -25,7 +25,7 @@
         <CommandBinding Command="Close" Executed="ExitCommandBinding_Executed"></CommandBinding>
         <CommandBinding Command="local:MainWindow.OpenAboutCommand" Executed="OpenAboutCommandBinding_Executed" />
         <CommandBinding Command="local:MainWindow.OpenUserSettingsCommand" Executed="OpenUserSettingsCommandBinding_Executed" />
-        
+        <CommandBinding Command="Refresh" Executed="RefreshCommandBinding_Executed" />
     </Window.CommandBindings>
 
     <Window.InputBindings>
@@ -78,6 +78,8 @@
                 <Separator Height="3" Margin="0"/>
                 <MenuItem x:Name="_FullPathItem" Header="Full Paths" Height="25" InputGestureText="F9" IsCheckable="True" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=FullPath, Mode=TwoWay}" Margin="0,0,0.2,0"/>
                 <MenuItem Header="_Undecorate C++ Functions" Height="26" InputGestureText="F10" IsCheckable="True" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=Undecorate, Mode=TwoWay }"/>
+                <Separator Height="3" Margin="0"/>
+                <MenuItem x:Name="_RefreshItem" Header="_Refresh" Height="25" InputGestureText="F5" IsEnabled="False"/>
                 <Separator Height="3" Margin="0"/>
                 <MenuItem x:Name="_StatusBarItem" Header="Status Bar" Height="25" IsCheckable="True" Margin="0" IsChecked="{Binding Source={x:Static properties:Settings.Default}, Path=ShowStatusBar, Mode=TwoWay}"/>
             </MenuItem>

--- a/DependenciesGui/MainWindow.xaml.cs
+++ b/DependenciesGui/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Windows;
 using System.Windows.Input;
@@ -201,6 +201,11 @@ namespace Dependencies
             this.UserSettings = new UserSettings();
             this.UserSettings.Show();
         }
+
+        private void RefreshCommandBinding_Executed(object sender, RoutedEventArgs e)
+        {
+            (this.TabControl.SelectedItem as DependencyWindow).InitializeView();
+        }
         #endregion Commands
 
         #region EventsHandler
@@ -235,6 +240,7 @@ namespace Dependencies
         private void MainWindow_TabControlIsEmptyHandler(object sender, RoutedPropertyChangedEventArgs<bool> e)
         {
             this.DefaultMessage.Visibility = (e.NewValue) ? Visibility.Visible : Visibility.Hidden;
+            this._RefreshItem.IsEnabled = !e.NewValue;
         }
         #endregion EventsHandler
     }


### PR DESCRIPTION
It's helpful to be able to refresh the current tab, particularly when consolidating an executable and its dependent DLLs into a folder.  This allows the user to refresh and see what remaining DLLs can't be found so that the they can be added to the folder.