### PR TITLE
Handle null pointer in case of unresolved module paths

### DIFF
--- a/Dependencies/Program.cs
+++ b/Dependencies/Program.cs
@@ -293,7 +293,7 @@ namespace Dependencies
 
                 if (Strategy != ModuleSearchStrategy.NOT_FOUND)
                 {
-                    ModuleFilepath = ResolvedModule.Item2.Filepath;
+                    ModuleFilepath = ResolvedModule.Item2?.Filepath;
                 }
 
 


### PR DESCRIPTION
Dependencies crashes when ModuleSearchStrategy is ApiSetSchema and the module cannot be found. I am not sure if the real problem is that the module path should have actually been found, but at least here is a quick fix. This is similar to DependenciesGui that simply ignores the entries, an alternative would be to return a NOT_FOUND string.

![nullapischema](https://user-images.githubusercontent.com/7031720/49796892-342d8c00-fd3e-11e8-828d-dc0f84654923.png)