### PR TITLE
An ordinal is not optional on exports

### DIFF
--- a/DependenciesGui/DependencyExportList.xaml
+++ b/DependenciesGui/DependencyExportList.xaml
@@ -57,7 +57,7 @@
             <GridViewColumn Header="Ordinal" Width="140" util:GridViewSort.PropertyName="Ordinal" HeaderContainerStyle="{StaticResource LeftAlignHeader}">
                 <GridViewColumn.CellTemplate>
                     <DataTemplate>
-                        <TextBlock Text="{Binding Ordinal, StringFormat={}{0} (0x{0:x08}), TargetNullValue='N/A' }" TextAlignment="Right" HorizontalAlignment="Right"/>
+                        <TextBlock Text="{Binding Ordinal, StringFormat={}{0} (0x{0:x04}) }" TextAlignment="Right" HorizontalAlignment="Right"/>
                     </DataTemplate>
                 </GridViewColumn.CellTemplate>
             </GridViewColumn>

--- a/DependenciesGui/Models/PeExport.cs
+++ b/DependenciesGui/Models/PeExport.cs
@@ -36,7 +36,7 @@ public class DisplayPeExport : SettingBindingHandler
 	public override string ToString()
 	{
 		List<string> members = new List<string>() {
-			Ordinal != null ? String.Format("{0} (0x{0:x08})", Ordinal) : "N/A",
+			String.Format("{0} (0x{0:x04})", Ordinal),
 			Hint != 0 ? String.Format("{0} (0x{0:x08})", Hint) : "N/A",
 			Name,
 			VirtualAddress,
@@ -76,7 +76,7 @@ public class DisplayPeExport : SettingBindingHandler
         }
     }
     public int Hint { get { return PeInfo.hint; } }
-    public int? Ordinal { get { if (PeInfo.exportByOrdinal) { return PeInfo.ordinal; } return null; } }
+    public int Ordinal { get { return PeInfo.ordinal; } }
 
     public string Name
     {


### PR DESCRIPTION
Always show it in the UI,
Always provide it in the `PeExport` object.