### PR TITLE
Show the target of a forwarder as VirtualAddress instead of hiding the original name

### DIFF
--- a/DependenciesGui/DependencyExportList.xaml
+++ b/DependenciesGui/DependencyExportList.xaml
@@ -69,7 +69,7 @@
                 </GridViewColumn.CellTemplate>
             </GridViewColumn>
             <GridViewColumn Header="Function" Width="250" DisplayMemberBinding="{Binding Name}" util:GridViewSort.PropertyName="Name" HeaderContainerStyle="{StaticResource LeftAlignHeader}"/>
-            <GridViewColumn Header="VirtualAddress" Width="100" DisplayMemberBinding="{Binding VirtualAddress, StringFormat={}0x{0:x08}}" util:GridViewSort.PropertyName="VirtualAddress" HeaderContainerStyle="{StaticResource LeftAlignHeader}"/>
+            <GridViewColumn Header="VirtualAddress" Width="250" DisplayMemberBinding="{Binding VirtualAddress}" util:GridViewSort.PropertyName="VirtualAddress" HeaderContainerStyle="{StaticResource LeftAlignHeader}"/>
             <GridViewColumn Header="Demangler" Width="250" DisplayMemberBinding="{Binding Demangler}" util:GridViewSort.PropertyName="Name" HeaderContainerStyle="{StaticResource LeftAlignHeader}"/>
         </GridView>
     </local:DependencyCustomListView.View>

--- a/DependenciesGui/Models/PeExport.cs
+++ b/DependenciesGui/Models/PeExport.cs
@@ -83,15 +83,20 @@ public class DisplayPeExport : SettingBindingHandler
         get { return GetDisplayName(Dependencies.Properties.Settings.Default.Undecorate); }
     }
 
-    public string VirtualAddress { get { return String.Format("0x{0:x8}", PeInfo.virtualAddress); } }
+    public string VirtualAddress
+    {
+        get
+        {
+            if (PeInfo.forwardedExport)
+                return PeInfo.ForwardName;
+            return String.Format("0x{0:x8}", PeInfo.virtualAddress);
+        }
+    }
 
     public string Demangler { get { return PeInfo.Demangler; } }
 
     protected string GetDisplayName(bool Undecorate)
     { 
-        if (PeInfo.forwardedExport)
-            return PeInfo.ForwardName;
-
         if (PeInfo.exportByOrdinal)
             return String.Format("Ordinal_{0:d}", PeInfo.ordinal);
 


### PR DESCRIPTION
Previously, the VirtualAddress would always be 0 for these entries,
and the export name was replaced with the target of the forwarder.
Since the target name does not have to be the same as the export name, this effectively 'hides' the exported function.