### PR TITLE
Ensure DelayLoad flag persists for api sets that are delay loaded

### DIFF
--- a/DependenciesGui/Models/ModuleInfo.cs
+++ b/DependenciesGui/Models/ModuleInfo.cs
@@ -105,12 +105,13 @@ namespace Dependencies
         {
             UnderlyingModule = _UnderlyingModule;
 
-			_Flags |= ModuleFlag.ApiSet;
-			if (ApiSetModuleName.StartsWith("ext-"))
-			{
-				_Flags |= ModuleFlag.ApiSetExt;
-			}
-		}
+            _Flags = _UnderlyingModule.Flags;
+            _Flags |= ModuleFlag.ApiSet;
+            if (ApiSetModuleName.StartsWith("ext-"))
+            {
+                _Flags |= ModuleFlag.ApiSetExt;
+            }
+        }
 
         public override string ModuleName { get { return String.Format("{0:s} -> {1:s}", this._Name, UnderlyingModule.ModuleName);}}
         public override string Filepath { get { return UnderlyingModule.Filepath; } }

--- a/DependenciesLib/FindPeModule.cs
+++ b/DependenciesLib/FindPeModule.cs
@@ -205,7 +205,7 @@ namespace Dependencies
 
 
             // 8. Check if it's an absolute import
-            if ((Path.GetFullPath(ModuleName) == ModuleName) && File.Exists(ModuleName))
+            if (ModuleName != "" && (Path.GetFullPath(ModuleName) == ModuleName) && File.Exists(ModuleName))
             {
                 return new Tuple<ModuleSearchStrategy, string>(
                    ModuleSearchStrategy.Fullpath,


### PR DESCRIPTION
Small change to ensure that the DelayLoad flag is passed through to the ApiSetModuleInfo so delay loaded api set modules have a hour glass icon in the UI.  This matches the behavior of the old Depends.exe.  Also fixed some tabs in the source file around the change and fixed a issue with an exception raised with an empty string I hit during development.