### PR TITLE
Improved "UserSettings" window layout.

### DIFF
--- a/DependenciesGui/MainWindow.xaml.cs
+++ b/DependenciesGui/MainWindow.xaml.cs
@@ -212,6 +212,7 @@ namespace Dependencies
         {
             this.UserSettings.Close();
             this.UserSettings = new UserSettings();
+            this.UserSettings.Owner = this;
             this.UserSettings.Show();
         }
 

--- a/DependenciesGui/UserSettings.xaml
+++ b/DependenciesGui/UserSettings.xaml
@@ -8,116 +8,101 @@
         xmlns:System="clr-namespace:System;assembly=mscorlib"
         mc:Ignorable="d"
         Title="UserSettings"
-        SizeToContent="WidthAndHeight" Height="251.953" Width="704.297">
+        Height="400" Width="700"
+        WindowStartupLocation="CenterOwner">
     <Window.Resources>
         <local:TreeBuildingBehaviour x:Key="TreeBuildingBehaviourConverter"/>
     </Window.Resources>
-    <Grid Margin="10 20 20 20" MinHeight="100"  MinWidth="600">
+    <Grid Margin="10 20 20 20" >
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>
-            <RowDefinition Height="5*"/>
-            <RowDefinition Height="33*"/>
-            <RowDefinition Height="33*"/>
-            <RowDefinition Height="33*"/>
-            <RowDefinition Height="33*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+        
+        
+        <!-- Previewer Path selection -->
+        <Label Content="Peviewer path:"
+               Margin="5"
+               Grid.Column="0"
+               Grid.Row="0"
+               HorizontalAlignment="Left" 
+               VerticalAlignment="Center" />
 
-        <Grid Grid.Row="1">
+        <Grid Margin="5" Grid.Row="0" Grid.Column="1">
+
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="100"/>
-                <ColumnDefinition Width="80*"/>
-                <ColumnDefinition Width="30"/>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Label Content="Peviewer path:" 
-                   HorizontalAlignment="Left" 
-                   VerticalAlignment="Center"
-                   Grid.Column="0"
-                   Height="25"
-                   />
+            <TextBox Grid.Column="0"
+                     Text="{Binding Source={x:Static properties:Settings.Default}, Path=PeViewerPath, Mode=OneWay}"
+                     TextWrapping="Wrap" 
+                     VerticalContentAlignment="Center" />
 
-            <TextBox Text="{Binding Source={x:Static properties:Settings.Default}, Path=PeViewerPath, Mode=OneWay}"
-                    TextWrapping="Wrap" 
-                    HorizontalContentAlignment="Stretch"
-                    HorizontalAlignment="Stretch"
-                    Height="20"
-                    Width="auto" 
+            <Button Margin="2 0 0 0"
                     Grid.Column="1"
-                    />
-
-            <Button Content="..." 
-                    Height="20"
-                    Margin="2 0 0 0"
-                    Click="OnPeviewerPathSettingChange"
-                    Grid.Column="2"/>
+                    Width="30"
+                    Content="..."
+                    Click="OnPeviewerPathSettingChange" />
         </Grid>
 
-        <Grid Grid.Row="2">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="150"/>
-                <ColumnDefinition Width="80*"/>
-            </Grid.ColumnDefinitions>
+        
+        <!-- Tree build behaviour selection -->
+        <Label Margin="5" 
+               Grid.Row="1"
+               Grid.Column="0"
+               Content="Tree build behaviour:" 
+               HorizontalAlignment="Left" 
+               VerticalAlignment="Center" />
 
-            <Label Content="Tree build behaviour:" 
-                   HorizontalAlignment="Left" 
-                   VerticalAlignment="Center"
-                   Grid.Column="0"
-                   Height="25"
-                   />
+        <ComboBox x:Name="TreeBuildCombo"
+                  Margin="5"
+                  Grid.Row="1"
+                  Grid.Column="1" 
+                  SelectedItem="{Binding Source={x:Static properties:Settings.Default}, Path=TreeBuildBehaviour, Mode=OneWay, Converter={StaticResource TreeBuildingBehaviourConverter}}"
+                  />
 
-            <ComboBox x:Name="TreeBuildCombo"
-                      SelectedItem="{Binding Source={x:Static properties:Settings.Default}, Path=TreeBuildBehaviour, Mode=OneWay, Converter={StaticResource TreeBuildingBehaviourConverter}}"
-                      HorizontalContentAlignment="Stretch"
-                      HorizontalAlignment="Stretch"
-                      Height="20"
-                      Width="auto" 
-                      Grid.Column="1"
-                    >
+        
+        <!-- Font family selection -->
+        <Label Margin="5"
+               Grid.Row="2"
+               Grid.Column="0"
+               Content="Font family:" 
+               HorizontalAlignment="Left" 
+               VerticalAlignment="Top" />
 
-            </ComboBox>
-        </Grid>
-
-        <Grid Grid.Row="3">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="150"/>
-                <ColumnDefinition Width="60*"/>
-            </Grid.ColumnDefinitions>
-
-            <Label Content="Font family:" 
-                   HorizontalAlignment="Left" 
-                   VerticalAlignment="Top"
-                   Grid.Column="0"
-                   Height="25"
-                   />
-
-            <ListBox Name="FontFamilyList"
-                     Grid.Column="1"
-                     VerticalAlignment="Stretch"
-                     VerticalContentAlignment="Stretch"
-                     HorizontalContentAlignment="Stretch"
-                     HorizontalAlignment="Stretch"
-                     />
-        </Grid>
-
-        <Grid Grid.Row="4">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="150*"/>
-                <ColumnDefinition Width="60"/>
-                <ColumnDefinition Width="60"/>
-            </Grid.ColumnDefinitions>
-
+        <ListBox Name="FontFamilyList"
+                 Margin="5"
+                 Grid.Row="2"
+                 Grid.Column="1" />
+        
+        
+        <!-- Buttons -->
+        <StackPanel Grid.Row="3" Grid.Column="1" 
+                    Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Cancel" 
                     Height="20"
-                    Margin="2 0 0 0"
-                    Click="OnCancel"
-                    Grid.Column="1"/>
+                    Width="60"
+                    Margin="2"
+                    Padding="2"
+                    Click="OnCancel" />
 
             <Button Content="OK" 
                     Height="20"
-                    Margin="2 0 0 0"
-                    Click="OnValidate"
-                    Grid.Column="2"/>
-        </Grid>
+                    Width="60"
+                    Margin="2"
+                    Padding="2"
+                    Click="OnValidate" />
+        </StackPanel>
 
     </Grid>
 </Window>


### PR DESCRIPTION
Fixes #79 issue.

I've also made the "MainWindow" owner of the "UserSettings" window, so that the property WindowStartupLocation="CenterOwner" can be used on the UserSettings window.

This is the resulting behaviour:
![after](https://user-images.githubusercontent.com/34475384/61994805-c0977f80-b07f-11e9-9376-2d694fe1b6b7.gif)
