### PR TITLE
Added image type ARM64

### DIFF
--- a/DependenciesGui/Models/ModuleInfo.cs
+++ b/DependenciesGui/Models/ModuleInfo.cs
@@ -268,6 +268,9 @@ namespace Dependencies
                     case 0x01c4:/*IMAGE_FILE_MACHINE_ARMNT*/
                         return "ARM Thumb-2";
 
+                    case 0xAA64:/*IMAGE_FILE_MACHINE_ARM64*/
+                        return "ARM64";
+
                     default:
                         return "Unknown";
                 }


### PR DESCRIPTION
Windows on ARM laptops have been out there for over an year, but now the Surface Pro X will ~~probably~~ hopefully make it more mainstream.