### PR TITLE
Allow us to grab a more recent version of PH's pewiew

### DIFF
--- a/Deploy-Dependencies.ps1
+++ b/Deploy-Dependencies.ps1
@@ -29,13 +29,14 @@ function Get-PeviewBinary {
   # get the zip file job artifacts
   Invoke-WebRequest -Uri "$apiUrl/buildjobs/$jobId/artifacts/$artifactFileName" -OutFile "./$artifactFileName"
 
-  $PhArchiveHash = (Get-FileHash -Algorithm SHA256 -Path "./$artifactFileName").Hash;
-
+  # get the platform subfolder within the artifact zip file
   $pePlatform = "32bit"
   if ($env:platform -eq "x64") {
     $pePlatform = "64bit"
   }
 
+  # check the expected hash before extracing binaries
+  $PhArchiveHash = (Get-FileHash -Algorithm SHA256 -Path "./$artifactFileName").Hash;
   if ($PhArchiveHash -eq $Hash) {
     &7z.exe x "./$artifactFileName" "$($pePlatform)/peview.exe";
     $PeviewBinaryFile = (Resolve-Path "./$($pePlatform)/peview.exe").Path;


### PR DESCRIPTION
This changes the way we can grab a given build version of Process Hacker's peview.
The build version can be chosen from https://ci.appveyor.com/project/processhacker/processhacker/history

To change the version, just change the version and expected hash passed to `Get-PeviewBinary`