### PR TITLE
msvsmon.exe fault

### DIFF
--- a/Dependencies.sln
+++ b/Dependencies.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2003
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependenciesGui", "DependenciesGui\DependenciesGui.csproj", "{9232B9B6-F2BA-44A3-B8A6-A352777F632C}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -53,13 +53,13 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Debug|ARM.ActiveCfg = Debug|x86
 		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Debug|x64.ActiveCfg = Debug|x64
 		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Debug|x64.Build.0 = Debug|x64
 		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Debug|x86.ActiveCfg = Debug|x86
 		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Debug|x86.Build.0 = Debug|x86
-		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Release|Any CPU.ActiveCfg = Release|x86
+		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Release|ARM.ActiveCfg = Release|x86
 		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Release|x64.ActiveCfg = Release|x64
 		{9232B9B6-F2BA-44A3-B8A6-A352777F632C}.Release|x64.Build.0 = Release|x64

--- a/DependenciesGui/DependencyWindow.xaml.cs
+++ b/DependenciesGui/DependencyWindow.xaml.cs
@@ -556,10 +556,12 @@ namespace Dependencies
                 // AppInitDlls are triggered by user32.dll, so if the binary does not import user32.dll they are not loaded.
                 if (ImportModule.PeFilePath == User32Filepath)
                 {
-                    string AppInitRegistryKey = (this.Pe.IsWow64Dll()) ?
+                    string AppInitRegistryKey =
+                       // When the X86 version DepenciesGui.exe program opens the WowAA32Node registry, it seems like a fault occurs.
+                       //(this.Pe.IsArm32Dll()) ?
+                       // "HKEY_LOCAL_MACHINE\\SOFTWARE\\WowAA32Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows" :
+                       (this.Pe.IsWow64Dll()) ?
                         "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows" :
-//                        (this.Pe.IsArm32Dll()) ?
-//                        "HKEY_LOCAL_MACHINE\\SOFTWARE\\WowAA32Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows" :
                         "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows";
 
                     int LoadAppInitDlls = (int)Registry.GetValue(AppInitRegistryKey, "LoadAppInit_DLLs", 0);

--- a/DependenciesGui/DependencyWindow.xaml.cs
+++ b/DependenciesGui/DependencyWindow.xaml.cs
@@ -557,7 +557,6 @@ namespace Dependencies
                 if (ImportModule.PeFilePath == User32Filepath)
                 {
                     string AppInitRegistryKey =
-                       // When the X86 version DepenciesGui.exe program opens the WowAA32Node registry, it seems like a fault occurs.
                        (this.Pe.IsArm32Dll()) ?
                         "SOFTWARE\\WowAA32Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows" :
                        (this.Pe.IsWow64Dll()) ?

--- a/DependenciesGui/DependencyWindow.xaml.cs
+++ b/DependenciesGui/DependencyWindow.xaml.cs
@@ -558,14 +558,16 @@ namespace Dependencies
                 {
                     string AppInitRegistryKey =
                        // When the X86 version DepenciesGui.exe program opens the WowAA32Node registry, it seems like a fault occurs.
-                       //(this.Pe.IsArm32Dll()) ?
-                       // "HKEY_LOCAL_MACHINE\\SOFTWARE\\WowAA32Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows" :
+                       (this.Pe.IsArm32Dll()) ?
+                        "SOFTWARE\\WowAA32Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows" :
                        (this.Pe.IsWow64Dll()) ?
-                        "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows" :
-                        "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows";
+                        "SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows" :
+                        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows";
 
-                    int LoadAppInitDlls = (int)Registry.GetValue(AppInitRegistryKey, "LoadAppInit_DLLs", 0);
-                    string AppInitDlls = (string)Registry.GetValue(AppInitRegistryKey, "AppInit_DLLs", "");
+                    RegistryKey localKey = RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, RegistryView.Registry64);
+                    localKey = localKey.OpenSubKey(AppInitRegistryKey);
+                    int LoadAppInitDlls = (int)localKey.GetValue("LoadAppInit_DLLs", 0);
+                    string AppInitDlls = (string)localKey.GetValue("AppInit_DLLs", "");
 
                     if ((LoadAppInitDlls != 0) && (AppInitDlls != ""))
                     {


### PR DESCRIPTION
On the Windows x64 machine, if you open the following file:

C:\Program Files (x86)\Microsoft Visual Studio\2019\Common7\IDE\Remote Debugger\x86\msvsmon.exe

An error occurs at this location.

DependenciesGui\DependencyWindow.xaml.cs:627
`                    AssemblyDefinition PeAssembly = AssemblyDefinition.ReadAssembly(newPe.Filepath);
`

Maybe when you open a file that's not a dotnet assembly, you get a fault.

I've revised it. Please review it.