### PR TITLE
Update "Lookup function on MSDN" links

### DIFF
--- a/DependenciesGui/Models/PeExport.cs
+++ b/DependenciesGui/Models/PeExport.cs
@@ -139,7 +139,7 @@ public class DisplayPeExport : SettingBindingHandler
                         return;
                     }
 
-                    Process.Start(@"http://search.msdn.microsoft.com/search/default.aspx?query=" + ExportName);
+                    Process.Start(@"https://docs.microsoft.com/search/?search=" + ExportName);
                 });
             }
 

--- a/DependenciesGui/Models/PeImport.cs
+++ b/DependenciesGui/Models/PeImport.cs
@@ -161,7 +161,7 @@ public class DisplayPeImport : SettingBindingHandler
                         return;
                     }
 
-                    Process.Start(@"http://search.msdn.microsoft.com/search/default.aspx?query=" + ExportName);
+                    Process.Start(@"https://docs.microsoft.com/search/?search=" + ExportName);
                 });
             }
 


### PR DESCRIPTION
Microsoft has migrated API documents to docs.microsoft.com, so I suggest we use the modern search page, https://docs.microsoft.com/search/, to lookup functions.