### PR TITLE
update the usage of cli

### DIFF
--- a/Dependencies/Program.cs
+++ b/Dependencies/Program.cs
@@ -632,6 +632,7 @@ namespace Dependencies
                 "Options :",
                 "  -h -help : display this help",
                 "  -json : activate json output.",
+		"  -depth : limit recursion depth when analyisng loaded modules or dependency chain. Default value is infinite.",
                 "  -apisets : dump the system's ApiSet schema (api set dll -> host dll)",
                 "  -apisetsdll : dump the ApiSet schema from apisetschema <FILE> (api set dll -> host dll)",
                 "  -knowndll : dump all the system's known dlls (x86 and x64)",


### PR DESCRIPTION
the [issue](https://github.com/lucasg/Dependencies/issues/120) is solved, but the usage and the issue is not updated.

test

```shell
Dependencies\bin\Releasex64> .\Dependencies.exe
Dependencies.exe : command line tool for dumping dependencies and various utilities.

Usage : Dependencies.exe [OPTIONS] <FILE>

Options :
  -h -help : display this help
  -json : activate json output.
  -depth : limit recursion depth when analyisng loaded modules or dependency chain. Default value is infinite.
  -apisets : dump the system's ApiSet schema (api set dll -> host dll)
  -apisetsdll : dump the ApiSet schema from apisetschema <FILE> (api set dll -> host dll)
  -knowndll : dump all the system's known dlls (x86 and x64)
  -manifest : dump <FILE> embedded manifest, if it exists.
  -sxsentries : dump all of <FILE>'s sxs dependencies.
  -imports : dump <FILE> imports
  -exports : dump <FILE> exports
  -modules : dump <FILE> resolved modules
  -chain : dump <FILE> whole dependency chain
```