### PR TITLE
Trim and blank lines from text read from manifest files to ensure XML can load successfully

### DIFF
--- a/DependenciesLib/SxsManifest.cs
+++ b/DependenciesLib/SxsManifest.cs
@@ -406,6 +406,9 @@ namespace Dependencies
                 PeManifest = new Regex("SXS_ASSEMBLY_VERSION").Replace(PeManifest, "\"\"");
                 PeManifest = new Regex("SXS_ASSEMBLY_NAME").Replace(PeManifest, "\"\"");
 
+                // Remove blank lines
+                PeManifest = Regex.Replace(PeManifest, @"^\s+$[\r\n]*", string.Empty, RegexOptions.Multiline);
+
                 using (XmlTextReader xReader = new XmlTextReader(PeManifest, XmlNodeType.Document, context))
                 {
                     XmlManifest = XDocument.Load(xReader);


### PR DESCRIPTION
While it is not valid XML, some manifest files can contain leading blank lines and still work.  I came across one of these and Dependencies crashed with a invalid XML exception with a manifest file for an exe in the same directory that had a leading blank line.  Fix is to ensure blank lines are removed.