### PR TITLE
Allow '/' character in directory path

### DIFF
--- a/DependenciesLib/FindPeModule.cs
+++ b/DependenciesLib/FindPeModule.cs
@@ -54,7 +54,8 @@ namespace Dependencies
 			{
 				// do not treat these characters as invalid since the are necessary
 				// for absolute imports
-				if (InvalidChar == ':' || InvalidChar == '\\')
+                // also allow '/' because path env var manages it
+				if (InvalidChar == ':' || InvalidChar == '\\' || InvalidChar == '/')
 					continue;
 
 				if (Filepath.IndexOf(InvalidChar) != -1)


### PR DESCRIPTION
Since Windows path environment variable handle the '/' as a valid separator, I find interesting that Dependencies does too :)