### PR TITLE
Mod and assm refs added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tests/
 *.user
 
 _ReSharper.Caches/
+/**/x64-Debug

--- a/Dependencies/Dependencies.csproj
+++ b/Dependencies/Dependencies.csproj
@@ -81,6 +81,18 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.0\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
     <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
     </Reference>

--- a/Dependencies/Program.cs
+++ b/Dependencies/Program.cs
@@ -270,9 +270,17 @@ namespace Dependencies
         {
             Application = _Application;
 
-            var PeAssembly = AssemblyDefinition.ReadAssembly(Application.Filepath);
+            try
+            {
+                var PeAssembly = AssemblyDefinition.ReadAssembly(Application.Filepath);
 
-            ModuleReferences = PeAssembly.Modules.SelectMany(m => m.ModuleReferences).Where(mr => mr.Name.Length > 0);
+                ModuleReferences = PeAssembly.Modules.SelectMany(m => m.ModuleReferences)
+                    .Where(mr => mr.Name.Length > 0);
+            }
+            catch (BadImageFormatException)
+            {
+
+            }
 
         }
 
@@ -290,7 +298,7 @@ namespace Dependencies
 
         private PE Application;
 
-        public IEnumerable<ModuleReference> ModuleReferences { get; private set; }
+        public IEnumerable<ModuleReference> ModuleReferences { get; private set; } = new List<ModuleReference>();
     }
 
     internal class PEAssemblyReferences : IPrettyPrintable
@@ -299,10 +307,15 @@ namespace Dependencies
         {
             Application = _Application;
 
-            var PeAssembly = AssemblyDefinition.ReadAssembly(Application.Filepath);
+            try
+            {
+                var PeAssembly = AssemblyDefinition.ReadAssembly(Application.Filepath);
 
-            AssemblyReferences = PeAssembly.Modules.SelectMany(m => m.AssemblyReferences);
-
+                AssemblyReferences = PeAssembly.Modules.SelectMany(m => m.AssemblyReferences);
+            }
+            catch (BadImageFormatException)
+            {
+            }
         }
 
         public void PrettyPrint()
@@ -318,7 +331,9 @@ namespace Dependencies
         }
 
         private PE Application;
-        public IEnumerable<AssemblyNameReference> AssemblyReferences { get; private set; }
+
+        public IEnumerable<AssemblyNameReference> AssemblyReferences { get; private set; } =
+            new List<AssemblyNameReference>();
     }
 
     class ImportDll

--- a/Dependencies/Program.cs
+++ b/Dependencies/Program.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using NDesk.Options;
 using Newtonsoft.Json;
 using Dependencies.ClrPh;
+using Mono.Cecil;
 
 namespace Dependencies
 {
@@ -263,6 +264,83 @@ namespace Dependencies
     }
 
 
+    internal class PEModuleReferences : IPrettyPrintable
+    {
+        public PEModuleReferences(PE _Application)
+        {
+            Application = _Application;
+
+            var PeAssembly = AssemblyDefinition.ReadAssembly(Application.Filepath);
+
+            ModuleReferences = PeAssembly.Modules.SelectMany(m => m.ModuleReferences).Where(mr => mr.Name.Length > 0);
+
+        }
+
+        public void PrettyPrint()
+        {
+            Console.WriteLine("[-] Module references listing for file : {0}", Application.Filepath);
+
+            foreach (ModuleReference moduleReference in ModuleReferences)
+            {
+                Console.WriteLine("Import module {0:s} :", moduleReference.Name);
+            }
+
+            Console.WriteLine("[-] Import listing done");
+        }
+
+        private PE Application;
+
+        public IEnumerable<ModuleReference> ModuleReferences { get; private set; }
+    }
+
+    internal class PEAssemblyReferences : IPrettyPrintable
+    {
+        public PEAssemblyReferences(PE _Application)
+        {
+            Application = _Application;
+
+            var PeAssembly = AssemblyDefinition.ReadAssembly(Application.Filepath);
+
+            AssemblyReferences = PeAssembly.Modules.SelectMany(m => m.AssemblyReferences);
+
+        }
+
+        public void PrettyPrint()
+        {
+            Console.WriteLine("[-] Module references listing for file : {0}", Application.Filepath);
+
+            foreach (AssemblyNameReference assemblyReference in AssemblyReferences)
+            {
+                Console.WriteLine("Import assembly {0:s} :", assemblyReference.Name);
+            }
+
+            Console.WriteLine("[-] Import listing done");
+        }
+
+        private PE Application;
+        public IEnumerable<AssemblyNameReference> AssemblyReferences { get; private set; }
+    }
+
+    class ImportDll
+    {
+        public string Name { get; private set; }
+
+        public static ImportDll From(PeImportDll i)
+        {
+            return new ImportDll
+            {
+                Name = i.Name
+            };
+        }
+        public static ImportDll From(ModuleReference m)
+        {
+            return new ImportDll
+            {
+                Name = m.Name
+            };
+        }
+    }
+
     class PeDependencyItem : IPrettyPrintable
     {
 
@@ -274,7 +352,7 @@ namespace Dependencies
                 ModuleName = _ModuleName;
 
 
-    			Imports = new List<PeImportDll>();
+    			Imports = new List<ImportDll>();
     			Filepath = ModuleFilepath;
                 SearchStrategy = Strategy;
                 RecursionLevel = Level;
@@ -282,6 +360,8 @@ namespace Dependencies
                 DependenciesResolved = false;
                 FullDependencies = new List<PeDependencyItem>();
     			ResolvedImports = new List<PeDependencyItem>();
+                ModuleReferences = new List<ImportDll>();
+                AssemblyReferences = new List<AssemblyNameReference>();
             };
 
             SafeExecutor(action);
@@ -294,9 +374,19 @@ namespace Dependencies
     			if (Filepath != null)
     			{
     				PE Module = BinaryCache.LoadPe(Filepath);
-    				Imports = Module.GetImports();
-    			}
-    			else
+    				Imports = Module.GetImports().Select(i => ImportDll.From(i)).ToList();
+
+                    try
+                    {
+                        var PeAssembly = AssemblyDefinition.ReadAssembly(Filepath);
+
+                        ModuleReferences = PeAssembly.Modules.SelectMany(m => m.ModuleReferences).Where(mr => mr.Name.Length > 0).Select(m => ImportDll.From(m)).ToList();
+                        AssemblyReferences = PeAssembly.Modules.SelectMany(m => m.AssemblyReferences).ToList();
+                    } catch (BadImageFormatException)
+                    {
+                    }
+                }
+                else
     			{
     				//Module = null;
     			}
@@ -316,7 +406,7 @@ namespace Dependencies
 
                 List<PeDependencyItem> NewDependencies = new List<PeDependencyItem>();
 
-                foreach (PeImportDll DllImport in Imports)
+                foreach (ImportDll DllImport in Imports.Concat(ModuleReferences))
                 {
                     string ModuleFilepath = null;
                     ModuleSearchStrategy Strategy;
@@ -452,10 +542,13 @@ namespace Dependencies
             get { return IsNewModule() ? FullDependencies : new List<PeDependencyItem>(); }
         }
 
+
         // not Json exportable
         protected List<PeDependencyItem> FullDependencies;
 		protected List<PeDependencyItem> ResolvedImports;
-		protected List<PeImportDll> Imports;
+		protected List<ImportDll> Imports;
+        protected List<AssemblyNameReference> AssemblyReferences;
+        protected List<ImportDll> ModuleReferences;
         protected PeDependencies Root;
         protected int RecursionLevel;
 
@@ -627,6 +720,17 @@ namespace Dependencies
             PEImports Imports = new PEImports(Pe);
             Printer(Imports);
         }
+        public static void DumpAssemblyReferences(PE Pe, Action<IPrettyPrintable> Printer, int recursion_depth = 0)
+        {
+            PEAssemblyReferences AssemblyReferences = new PEAssemblyReferences(Pe);
+            Printer(AssemblyReferences);
+        }
+
+        public static void DumpModuleReferences(PE Pe, Action<IPrettyPrintable> Printer, int recursion_depth = 0)
+        {
+            PEModuleReferences ModuleReferences = new PEModuleReferences(Pe);
+            Printer(ModuleReferences);
+        }
 
         public static void DumpDependencyChain(PE Pe, Action<IPrettyPrintable> Printer, int recursion_depth = 0)
         {
@@ -708,6 +812,8 @@ namespace Dependencies
                             { "sxsentries", "dump all of <FILE>'s sxs dependencies", v => command = DumpSxsEntries },
                             { "imports", "dump <FILE> imports", v => command = DumpImports },
                             { "exports", "dump <FILE> exports", v => command = DumpExports },
+                            { "assemblyrefs", "dump <FILE> assemblyrefs", v => command = DumpAssemblyReferences},
+                            { "modulerefs", "dump <FILE> modulerefs", v => command = DumpModuleReferences},
                             { "chain", "dump <FILE> whole dependency chain", v => command = DumpDependencyChain },
                             { "modules", "dump <FILE> resolved modules", v => command = DumpModules },
 						};

--- a/Dependencies/packages.config
+++ b/Dependencies/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Mono.Cecil" version="0.10.0" targetFramework="net461" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Despite GUI, commandline dependencies does not support printing out module and assembly refs. As I work on a project where we need to analyze hundreds of assemblies/dll this is really needed for us.