### PR TITLE
Implement "Copy File Path" command in module tree

### DIFF
--- a/DependenciesGui/DependencyModuleList.xaml
+++ b/DependenciesGui/DependencyModuleList.xaml
@@ -32,7 +32,7 @@
                                     Header = "{Binding DataContext.ModuleName, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Grid}}"
                                     Command="{Binding Path=DataContext.CopyValue, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Grid},AncestorLevel=1 }}"
                                     CommandParameter ="{Binding DataContext.ModuleName, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Grid }}"
-                                    InputGestureText="Ctrl+C"  
+                                    InputGestureText="Ctrl+C"
                                     IsEnabled="True"/>
             <MenuItem Header="Select All" 
                                 Command="ApplicationCommands.SelectAll" 

--- a/DependenciesGui/DependencyWindow.xaml
+++ b/DependenciesGui/DependencyWindow.xaml
@@ -55,14 +55,14 @@
                         <MenuItem Header="Highlight Matching Module In List" 
                                 Command="{StaticResource DoFindModuleInList}"
                                 CommandParameter="{Binding RelativeSource={RelativeSource  AncestorLevel=1,AncestorType=TreeViewItem,Mode=FindAncestor}}"
-                                InputGestureText="Ctrl+M" 
+                                InputGestureText="Ctrl+M"
                                 IsEnabled="True" />
                         <Separator Height="3" Margin="-1,0,0,0"/>
                         <MenuItem Header="Copy File Path" 
-                                Command="{Binding Path=DataContext.MoreInfo, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListView}}" 
+                                Command="{Binding Path=CopyFilePathCommand, RelativeSource={RelativeSource AncestorLevel=1,AncestorType=TreeViewItem,Mode=FindAncestor}}"
                                 Background="WhiteSmoke" 
-                                InputGestureText="Ctrl+C" 
-                                IsEnabled="False"  />
+                                InputGestureText="Ctrl+C"
+                                IsEnabled="True"  />
                         <Separator Height="3" Margin="-1,0,0,0"/>
                         <MenuItem Header="Expand All" 
                                 Command="{StaticResource DoExpandAllNodes}"
@@ -75,7 +75,7 @@
                         <Separator Height="3" Margin="-1,0,0,0"/>
 
                         <MenuItem Header="View Module in separate application" 
-                                Command="{Binding  Path=OpenNewAppCommand, RelativeSource={RelativeSource AncestorLevel=1,AncestorType=TreeViewItem,Mode=FindAncestor}}"
+                                Command="{Binding Path=OpenNewAppCommand, RelativeSource={RelativeSource AncestorLevel=1,AncestorType=TreeViewItem,Mode=FindAncestor}}"
                                 CommandParameter ="{Binding DataContext, RelativeSource={RelativeSource AncestorLevel=1,AncestorType=Grid,Mode=FindAncestor}}"
                                 InputGestureText="Alt+Enter"  
                                 IsEnabled="True" />

--- a/DependenciesGui/DependencyWindow.xaml.cs
+++ b/DependenciesGui/DependencyWindow.xaml.cs
@@ -495,15 +495,44 @@ namespace Dependencies
             }
         }
 
+        public RelayCommand CopyFilePathCommand
+        {
+            get
+            {
+                if (_CopyFilePathCommand == null)
+                {
+                    _CopyFilePathCommand = new RelayCommand((param) =>
+                    {
+                        string filePath = ModuleFilePath;
+                        if (filePath == null)
+                        {
+                            return;
+                        }
+
+                        Clipboard.Clear();
+
+                        try
+                        {
+
+                            Clipboard.SetText(filePath, TextDataFormat.Text);
+                        }
+                        catch { }
+                    });
+                }
+
+                return _CopyFilePathCommand;
+            }
+        }
+
         #endregion // Commands 
 
         private RelayCommand _OpenPeviewerCommand;
         private RelayCommand _OpenNewAppCommand;
-		private ModuleTreeViewItem _Parent;
+        private RelayCommand _CopyFilePathCommand;
+
+        private ModuleTreeViewItem _Parent;
 		private bool _importsVerified;
         private bool _has_child_errors;
-
-
     }
 
 


### PR DESCRIPTION
I re-used the code inside `CopyValue` command in another view.

The Ctrl-C shortcut doesn't work though... It looks like the shortcuts are not wired to the respective commands in this view, so I thought that a better  approach would be to fix the shortcuts for all menu commands at once in a different PR.