### PR TITLE
MEDIUM: Potentially Unsafe Code - Potential Memory Leak

### DIFF
--- a/third_party/phlib/jsonc/arraylist.c
+++ b/third_party/phlib/jsonc/arraylist.c
@@ -57,6 +57,7 @@ array_list_get_idx(struct array_list *arr, int i)
   return arr->array[i];
 }
 
+
 static int array_list_expand_internal(struct array_list *arr, int max)
 {
   void *t;
@@ -64,12 +65,17 @@ static int array_list_expand_internal(struct array_list *arr, int max)
 
   if(max < arr->size) return 0;
   new_size = json_max(arr->size << 1, max);
-  if(!(t = realloc(arr->array, new_size*sizeof(void*)))) return -1;
+  t = realloc(arr->array, new_size*sizeof(void*));
+  if(!t) {
+    free(arr->array);
+    return -1;
+  }
   arr->array = (void**)t;
   (void)memset(arr->array + arr->size, 0, (new_size-arr->size)*sizeof(void*));
   arr->size = new_size;
   return 0;
 }
+
 
 int
 array_list_put_idx(struct array_list *arr, int idx, void *data)


### PR DESCRIPTION
_Dear author, Hello！_
_I found a small security breach，_
_I've modified it，_
_I hope you can merge it。_
_(My English is not very good, I hope the wording does not offend you)_

### Description-MEDIUM: Potentially Unsafe Code - Potential Memory Leak
Line: 71 - Dependencies\third_party\phlib\jsonc\arraylist.c
Source code may experience memory leaks when attempting to extend arrays. 
If the realloc function fails and returns NULL, the original memory is still retained.

### Solution
solve this problem by checking the return value of realloc after calling it. 
If realloc returns NULL, the original memory should be freed and an error returned.

### Modified code
```static int array_list_expand_internal(struct array_list *arr, int max)
{
  void *t;
  int new_size;

  if(max < arr->size) return 0;
  new_size = json_max(arr->size << 1, max);
  t = realloc(arr->array, new_size*sizeof(void*));
  if(!t) {
    free(arr->array);
    return -1;
  }
  arr->array = (void**)t;
  (void)memset(arr->array + arr->size, 0, (new_size-arr->size)*sizeof(void*));
  arr->size = new_size;
  return 0;
}```


  
 
