### PR TITLE
Update hyperlink for Visual C++ Redistributable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 #### [(If you're running an AV, use this download instead)](https://github.com/lucasg/Dependencies/releases/download/v1.11.1/Dependencies_x64_Release_.without.peview.exe.zip)
 
-NB : due to [limitations on /clr compilation](https://msdn.microsoft.com/en-us/library/ffkc918h.aspx), `Dependencies` needs [Visual C++  Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) installed to run properly.
+NB : due to [limitations on /clr compilation](https://msdn.microsoft.com/en-us/library/ffkc918h.aspx), `Dependencies` needs [Visual C++  Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) installed to run properly.
 
 <p align="center">
 <img alt="Usage Exemple" src="screenshots/UsageExemple.gif"/>


### PR DESCRIPTION
The previous hyperlink yielded HTTP 404.